### PR TITLE
Update links for the online version to https://rsmp-nordic.github.io

### DIFF
--- a/pages/specification.md
+++ b/pages/specification.md
@@ -33,19 +33,19 @@ View the [GitHub repository](https://github.com/rsmp-nordic/rsmp_core).
 | 3.1.2          | [Online][core_3.1.2_online], [PDF][core_3.1.2_pdf] |
 
 [core_3.2_pdf]: https://github.com/rsmp-nordic/rsmp_core/releases/download/v3.2/rsmp-spec-3.2.pdf
-[core_3.2_online]: https://rsmp-nordic.org/rsmp_specifications/core/3.2
+[core_3.2_online]: https://rsmp-nordic.github.io/rsmp_specifications/core/3.2/
 
 [core_3.1.5_pdf]: https://github.com/rsmp-nordic/rsmp_core/releases/download/v3.1.5/rsmp-spec-3.1.5.pdf
-[core_3.1.5_online]: https://rsmp-nordic.org/rsmp_specifications/core/3.1.5
+[core_3.1.5_online]: https://rsmp-nordic.github.io/rsmp_specifications/core/3.1.5
 
 [core_3.1.4_pdf]: https://github.com/rsmp-nordic/rsmp_core/releases/download/v3.1.4/rsmp-spec-3.1.4.pdf
-[core_3.1.4_online]: https://rsmp-nordic.org/rsmp_specifications/core/3.1.4
+[core_3.1.4_online]: https://rsmp-nordic.github.io/rsmp_specifications/core/3.1.4
 
 [core_3.1.3_pdf]: https://github.com/rsmp-nordic/rsmp_core/releases/download/v3.1.3/rsmp-spec-3.1.3.pdf
-[core_3.1.3_online]: https://rsmp-nordic.org/rsmp_specifications/core/3.1.3
+[core_3.1.3_online]: https://rsmp-nordic.github.io/rsmp_specifications/core/3.1.3
 
 [core_3.1.2_pdf]: https://github.com/rsmp-nordic/rsmp_core/releases/download/v3.1.2/rsmp-spec-3.1.2.pdf
-[core_3.1.2_online]: https://rsmp-nordic.org/rsmp_specifications/core/3.1.2
+[core_3.1.2_online]: https://rsmp-nordic.github.io/rsmp_specifications/core/3.1.2
 
 
 ## Traffic Light Controller SXL
@@ -61,11 +61,11 @@ View the [GitHub repository](https://github.com/rsmp-nordic/rsmp_sxl_traffic_lig
 
 [tlc_1.1_pdf]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/1.1/sxl-tlc-1.1.pdf
 [tlc_1.1_excel]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/1.1/SXL_Traffic_Controller_ver_1_1.xlsx
-[tlc_1.1_online]: https://rsmp-nordic.org/rsmp_specifications/rsmp_sxl_traffic_lights/1.1
+[tlc_1.1_online]: https://rsmp-nordic.github.io/rsmp_specifications/rsmp_sxl_traffic_lights/1.1
 
 [tlc_1.0.15_pdf]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/1.0.15/sxl-tlc-1.0.15.pdf
 [tlc_1.0.15_excel]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/1.0.15/SXL_Traffic_Controller_ver_1_0_15-2020-10-30.xlsx
-[tlc_1.0.15_online]: https://rsmp-nordic.org/rsmp_specifications/rsmp_sxl_traffic_lights/1.0.15/
+[tlc_1.0.15_online]: https://rsmp-nordic.github.io/rsmp_specifications/rsmp_sxl_traffic_lights/1.0.15/
 
 [tlc_1.0.14_excel]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/1.0.14/SXL_Traffic_Controller_ver_1_0_14-2017-10-30.xlsx
 [tlc_1.0.14_github]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/blob/1.0.14/sxl_traffic_controller.md


### PR DESCRIPTION
The links to the online version of Core and SXL are broken on the website.
First reported here: https://github.com/rsmp-nordic/rsmp_specifications/issues/7

I have no clue what may have caused this, since I don't believe we've made any changes that might affect this.

This PR updates the links one the website to use https://rsmp-nordic.github.io instead, where the online version still is available.