### PR TITLE
Update links to specification

### DIFF
--- a/pages/specification.md
+++ b/pages/specification.md
@@ -34,25 +34,25 @@ View the [GitHub repository](https://github.com/rsmp-nordic/rsmp_core).
 | 3.1.3          | [Online][core_3.1.3_online], [PDF][core_3.1.3_pdf] |
 | 3.1.2          | [Online][core_3.1.2_online], [PDF][core_3.1.2_pdf] |
 
-[core_3.2.2_online]: https://rsmp-nordic.github.io/rsmp_specifications/core/3.2.2/
+[core_3.2.2_online]: https://rsmp-nordic.github.io/rsmp_core/3.2.2/
 
 [core_3.2.1_pdf]: https://github.com/rsmp-nordic/rsmp_core/releases/download/v3.2.1/rsmp-spec-3.2.1.pdf
-[core_3.2.1_online]: https://rsmp-nordic.github.io/rsmp_specifications/core/3.2.1/
+[core_3.2.1_online]: https://rsmp-nordic.github.io/rsmp_core/3.2.1/
 
 [core_3.2_pdf]: https://github.com/rsmp-nordic/rsmp_core/releases/download/v3.2/rsmp-spec-3.2.pdf
-[core_3.2_online]: https://rsmp-nordic.github.io/rsmp_specifications/core/3.2/
+[core_3.2_online]: https://rsmp-nordic.github.io/rsmp_core/3.2/
 
 [core_3.1.5_pdf]: https://github.com/rsmp-nordic/rsmp_core/releases/download/v3.1.5/rsmp-spec-3.1.5.pdf
-[core_3.1.5_online]: https://rsmp-nordic.github.io/rsmp_specifications/core/3.1.5
+[core_3.1.5_online]: https://rsmp-nordic.github.io/rsmp_core/3.1.5
 
 [core_3.1.4_pdf]: https://github.com/rsmp-nordic/rsmp_core/releases/download/v3.1.4/rsmp-spec-3.1.4.pdf
-[core_3.1.4_online]: https://rsmp-nordic.github.io/rsmp_specifications/core/3.1.4
+[core_3.1.4_online]: https://rsmp-nordic.github.io/rsmp_core/3.1.4
 
 [core_3.1.3_pdf]: https://github.com/rsmp-nordic/rsmp_core/releases/download/v3.1.3/rsmp-spec-3.1.3.pdf
-[core_3.1.3_online]: https://rsmp-nordic.github.io/rsmp_specifications/core/3.1.3
+[core_3.1.3_online]: https://rsmp-nordic.github.io/rsmp_core/3.1.3
 
 [core_3.1.2_pdf]: https://github.com/rsmp-nordic/rsmp_core/releases/download/v3.1.2/rsmp-spec-3.1.2.pdf
-[core_3.1.2_online]: https://rsmp-nordic.github.io/rsmp_specifications/core/3.1.2
+[core_3.1.2_online]: https://rsmp-nordic.github.io/rsmp_core/3.1.2
 
 
 ## Traffic Light Controller SXL
@@ -69,18 +69,18 @@ View the [GitHub repository](https://github.com/rsmp-nordic/rsmp_sxl_traffic_lig
 
 [tlc_1.2_pdf]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/v1.2/sxl-tlc-1.2.pdf
 [tlc_1.2_excel]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/v1.2/SXL_Traffic_Controller_ver_1_2.xlsx
-[tlc_1.2_online]: https://rsmp-nordic.github.io/rsmp_specifications/rsmp_sxl_traffic_lights/1.2
+[tlc_1.2_online]: https://rsmp-nordic.github.io/rsmp_sxl_traffic_lights/1.2
 
-[tlc_1.1_pdf]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/1.1/sxl-tlc-1.1.pdf
-[tlc_1.1_excel]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/1.1/SXL_Traffic_Controller_ver_1_1.xlsx
-[tlc_1.1_online]: https://rsmp-nordic.github.io/rsmp_specifications/rsmp_sxl_traffic_lights/1.1
+[tlc_1.1_pdf]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/v1.1/sxl-tlc-1.1.pdf
+[tlc_1.1_excel]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/v1.1/SXL_Traffic_Controller_ver_1_1.xlsx
+[tlc_1.1_online]: https://rsmp-nordic.github.io/rsmp_sxl_traffic_lights/1.1
 
-[tlc_1.0.15_pdf]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/1.0.15/sxl-tlc-1.0.15.pdf
-[tlc_1.0.15_excel]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/1.0.15/SXL_Traffic_Controller_ver_1_0_15-2020-10-30.xlsx
-[tlc_1.0.15_online]: https://rsmp-nordic.github.io/rsmp_specifications/rsmp_sxl_traffic_lights/1.0.15/
+[tlc_1.0.15_pdf]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/v1.0.15/sxl-tlc-1.0.15.pdf
+[tlc_1.0.15_excel]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/v1.0.15/SXL_Traffic_Controller_ver_1_0_15-2020-10-30.xlsx
+[tlc_1.0.15_online]: https://rsmp-nordic.github.io/rsmp_sxl_traffic_lights/1.0.15/
 
-[tlc_1.0.14_excel]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/1.0.14/SXL_Traffic_Controller_ver_1_0_14-2017-10-30.xlsx
-[tlc_1.0.14_github]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/blob/1.0.14/sxl_traffic_controller.md
+[tlc_1.0.14_excel]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/v1.0.14/SXL_Traffic_Controller_ver_1_0_14-2017-10-30.xlsx
+[tlc_1.0.14_github]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/blob/v1.0.14/sxl_traffic_controller.md
 
-[tlc_1.0.13_excel]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/1.0.13/SXL_Traffic_Controller_ver_1_0_13-2017-06-26.xlsx
-[tlc_1.0.13_github]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/blob/1.0.13/sxl_traffic_controller.md
+[tlc_1.0.13_excel]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/v1.0.13/SXL_Traffic_Controller_ver_1_0_13-2017-06-26.xlsx
+[tlc_1.0.13_github]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/blob/v1.0.13/sxl_traffic_controller.md


### PR DESCRIPTION
We've moved github pages to core and sxl repos and stopped using the rsmp_specification repo. This means that all links needs to be updated.