### PR TITLE
Fix the meeting times for the working groups

### DIFF
--- a/pages/groups.md
+++ b/pages/groups.md
@@ -21,8 +21,8 @@ Working group meetings happend every second week, on odd week numbers:
 
 |            | Tuesday       | Thursday                      |
 |------------|---------------|-------------------------------|
-| 10-11AM    | Core          | SXL Traffic Light Controllers |
-| 11-11AM    | Security      | Traffic Light Programming     |
+| 09-10AM    | Core          | SXL Traffic Light Controllers |
+| 10-11AM    | Security      | Traffic Light Programming     |
 | 11-12AM    | _break_       | _break_                       |
 | 12AM - 1PM | RSMP 4        | SXL Standardization           |
 


### PR DESCRIPTION
The time for the WG meetings seems off by one hour. I believe that this PR fixes it