### PR TITLE
Rename TLC SXL branches 1.1 => 1.1.0, 1.2 => 1.2.0

### DIFF
--- a/pages/specification.md
+++ b/pages/specification.md
@@ -67,8 +67,8 @@ View the [GitHub repository](https://github.com/rsmp-nordic/rsmp_sxl_traffic_lig
 | --- | --- |
 | 1.3.0 (draft)  | [Online][tlc_1.3.0_online] |
 | **1.2.1 (latest release)**  | [Online][tlc_1.2.1_online], [Excel][tlc_1.2.1_excel], [PDF][tlc_1.2.1_pdf] |
-| 1.2            | [Online][tlc_1.2_online], [Excel][tlc_1.2_excel], [PDF][tlc_1.2_pdf] |
-| 1.1            | [Online][tlc_1.1_online],    [Excel][tlc_1.1_excel],    [PDF][tlc_1.1_pdf]    |
+| 1.2.0          | [Online][tlc_1.2.0_online], [Excel][tlc_1.2.0_excel], [PDF][tlc_1.2.0_pdf] |
+| 1.1.0          | [Online][tlc_1.1.0_online], [Excel][tlc_1.1.0_excel], [PDF][tlc_1.1.0_pdf] |
 | 1.0.15         | [Online][tlc_1.0.15_online], [Excel][tlc_1.0.15_excel], [PDF][tlc_1.0.15_pdf] |
 | 1.0.14         | [GitHub][tlc_1.0.14_github], [Excel][tlc_1.0.14_excel] |
 | 1.0.13         | [GitHub][tlc_1.0.13_github], [Excel][tlc_1.0.13_excel] |
@@ -79,13 +79,13 @@ View the [GitHub repository](https://github.com/rsmp-nordic/rsmp_sxl_traffic_lig
 [tlc_1.2.1_excel]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/v1.2.1/SXL_Traffic_Controller_ver_1_2_1.xlsx
 [tlc_1.2.1_online]: https://rsmp-nordic.github.io/rsmp_sxl_traffic_lights/1.2.1
 
-[tlc_1.2_pdf]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/v1.2/sxl-tlc-1.2.pdf
-[tlc_1.2_excel]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/v1.2/SXL_Traffic_Controller_ver_1_2.xlsx
-[tlc_1.2_online]: https://rsmp-nordic.github.io/rsmp_sxl_traffic_lights/1.2
+[tlc_1.2_0_pdf]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/v1.2/sxl-tlc-1.2.pdf
+[tlc_1.2_0_excel]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/v1.2/SXL_Traffic_Controller_ver_1_2.xlsx
+[tlc_1.2_0_online]: https://rsmp-nordic.github.io/rsmp_sxl_traffic_lights/1.2.0
 
-[tlc_1.1_pdf]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/v1.1/sxl-tlc-1.1.pdf
-[tlc_1.1_excel]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/v1.1/SXL_Traffic_Controller_ver_1_1.xlsx
-[tlc_1.1_online]: https://rsmp-nordic.github.io/rsmp_sxl_traffic_lights/1.1
+[tlc_1.1_0_pdf]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/v1.1/sxl-tlc-1.1.pdf
+[tlc_1.1_0_excel]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/v1.1/SXL_Traffic_Controller_ver_1_1.xlsx
+[tlc_1.1_0_online]: https://rsmp-nordic.github.io/rsmp_sxl_traffic_lights/1.1.0
 
 [tlc_1.0.15_pdf]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/v1.0.15/sxl-tlc-1.0.15.pdf
 [tlc_1.0.15_excel]: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/releases/download/v1.0.15/SXL_Traffic_Controller_ver_1_0_15-2020-10-30.xlsx


### PR DESCRIPTION
The TLC SXL branches was recently renamed in:
https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/issues/244

The website needs to be updated to reflect this change.